### PR TITLE
Double player bug

### DIFF
--- a/app/views/player/_player.erb
+++ b/app/views/player/_player.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag "player-frame" do %>
+
   <div id="main-player"
     data-controller="audio-player"
     phx-hook="PlayerInitiator"
@@ -214,7 +214,7 @@
 
     <!-- Audio Element -->
     <audio data-audio-player-target="audio"
-      <%= params[:t] ? "data-ap=true" : "" %>
+     data-ap="true"
       src="<%= track.mp3_audio.url %>" 
       data-track-id="<%= track.slug %>" 
       id="audioElement">
@@ -222,4 +222,4 @@
   <div>
 
 </div>
-<% end %>
+

--- a/app/views/player/_player.erb
+++ b/app/views/player/_player.erb
@@ -214,7 +214,7 @@
 
     <!-- Audio Element -->
     <audio data-audio-player-target="audio"
-     data-ap="true"
+     <%= params[:t] ? "data-ap=true" : "" %>
       src="<%= track.mp3_audio.url %>" 
       data-track-id="<%= track.slug %>" 
       id="audioElement">

--- a/app/views/player/show.erb
+++ b/app/views/player/show.erb
@@ -1,2 +1,5 @@
+<%= turbo_frame_tag "player-frame" do %>
+    <%= render "player", track: @track, slideover:nil %>
 
-<%= render "player", track: @track, slideover:nil %>
+<% end %>
+


### PR DESCRIPTION
Bug: Two turbo frames are being instantiated after a track is requested from the UI. This is causing the same events to be triggered and eventually leads to multiple players playing at the same time and are unable to be accessed from the ui. 


Solution: By wrapping the show action in a turbo frame and removing it from the partial this fixes the issue. 

Caveat: The src attribute remains the same throughout all of the renders as you can't target the frame directly within itself, but it CAN be changed from the JS side and  is already doing so via stimulus anyways, it just isn't rendering the action in the html  ie . `<turbo-frame id="player-frame" src="/player?id=4" complete=""> ` even though it is being changed by stimulus.  So far I haven't had the player double on me and js controllers are behaving as expected.

we could also set the initial song to something like `@initial_song` in the controller to be set by admin or to associate with spotlight feature or something....just a thought.


I also have another commit changing `@track to track` in the partial. I wasn't sure if that was intentional or not and was a little curious about it. 